### PR TITLE
Filename argument to verbose argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Default: `false`
 
 Specify if this is SP2016 on-prem.
 
-### filename (optional)
+### verbose (optional)
 
 Type: `Boolean`
 Default: `false`


### PR DESCRIPTION
Filename argument is mentioned twice in readme but I assume the latter one should be verbose